### PR TITLE
Correct Scheddy URL for k8s liveness probe

### DIFF
--- a/overlays/prod/scheddy/deployment.yaml
+++ b/overlays/prod/scheddy/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /ping
+            path: /status
             port: http
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,3 +63,4 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30
+

--- a/overlays/prod/scheddy/deployment.yaml
+++ b/overlays/prod/scheddy/deployment.yaml
@@ -63,4 +63,3 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30
-

--- a/overlays/prod/scheddy/deployment.yaml
+++ b/overlays/prod/scheddy/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /ping
+            path: /status
             port: http
             scheme: HTTP
           periodSeconds: 15


### PR DESCRIPTION
Scheddy returns an HTTP 404 on `/ping`, so this liveness probe has 345,171 failed events in the VATUSA Kubernetes cluster. Fun! This PR changes that URL to `/status`, as identified by the Scheddy team as suitable for this purpose.